### PR TITLE
Fix unopened `</section>` tag

### DIFF
--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -63,7 +63,9 @@
                 <section class="wdn-grid-set">
                 <?php endif; ?>
 
-                    <?php print render($page['sidebar_first']); ?>
+                    <?php if($page['sidebar_first']): ?>
+                        <?php print render($page['sidebar_first']); ?>
+                    <?php endif; ?>
 
                     <?php if (isset($page['sidebar_first']['#region']) && isset($page['sidebar_second']['#region'])): ?>
                         <div class="<?php print theme_get_setting('grid_class_content_two_sidebars'); ?>">
@@ -77,7 +79,9 @@
                         <?php print render($page['content']); ?>
                     <?php endif; ?>
 
-                    <?php print render($page['sidebar_second']); ?>
+                    <?php if($page['sidebar_second']): ?>
+                        <?php print render($page['sidebar_second']); ?>
+                    <?php endif; ?>
 
                 <?php if ($page['sidebar_first'] || $page['sidebar_second']): ?>
                 </section>


### PR DESCRIPTION
Only render sidebars if they have content, otherwise the `$page['sidebar_first']` will be set to an array with a key that marks the sidebar as printed.

This is what was happening:
1. check if $page['sidebar_first'] has stuff (which it does NOT)
2. always print $page['sidebar_first'], which changes $page['sidebar_first'] into an array with a key of 'printed=true' (or something similar)
2. check if $page['sidebar_first'] has stuff (which it now does)
