### PR TITLE
Remove unneeded h2 for breadcrumbs

### DIFF
--- a/templates/breadcrumb.html.twig
+++ b/templates/breadcrumb.html.twig
@@ -1,7 +1,6 @@
 <nav id="breadcrumbs" class="wdn-inner-wrapper" role="navigation" aria-label="breadcrumbs">
   <!-- InstanceBeginEditable name="breadcrumbs" -->
 {% if breadcrumb %}
-  <h2 id="system-breadcrumb" class="visually-hidden">{{ 'Breadcrumb'|t }}</h2>
   <ul>
     {% for item in breadcrumb %}
       <li>


### PR DESCRIPTION
It looks like this was there for the default implementation to label the nav, but it is already labeled by `aria-label` and is in a non-editable area of the framework.